### PR TITLE
Remove unnecessary method that caused deprecation warnings

### DIFF
--- a/app/controllers/devise/checkga_controller.rb
+++ b/app/controllers/devise/checkga_controller.rb
@@ -14,7 +14,7 @@ class Devise::CheckgaController < Devise::SessionsController
   end
 
   def update
-    resource = resource_class.find_by_gauth_tmp(params[resource_name]['tmpid'])
+    resource = resource_class.find_by(gauth_tmp: params[resource_name]['tmpid'])
 
     if not resource.nil?
 

--- a/app/controllers/devise/recovery_codes_controller.rb
+++ b/app/controllers/devise/recovery_codes_controller.rb
@@ -26,7 +26,7 @@ class Devise::RecoveryCodesController < DeviseController
   end
 
   def verify_code
-    resource = resource_class.find_by_gauth_tmp(resource_params[:tmpid])
+    resource = resource_class.find_by(gauth_tmp: resource_params[:tmpid])
     if not resource.nil?
 
       if resource.valid_recovery_code?(resource_params[:gauth_recovery_code])

--- a/lib/devise_google_authenticatable/models/google_authenticatable.rb
+++ b/lib/devise_google_authenticatable/models/google_authenticatable.rb
@@ -96,9 +96,6 @@ module Devise # :nodoc:
       end
 
       module ClassMethods # :nodoc:
-        def find_by_gauth_tmp(gauth_tmp)
-          find(:first, :conditions => {:gauth_tmp => gauth_tmp})
-        end
         ::Devise::Models.config(self, :ga_timeout, :ga_timedrift, :ga_remembertime)
       end
     end

--- a/test/models/google_authenticatable_test.rb
+++ b/test/models/google_authenticatable_test.rb
@@ -47,8 +47,8 @@ class GoogleAuthenticatableTest < ActiveSupport::TestCase
 	end
 
 	test 'testing class method for finding by tmp key' do
-		assert User.find_by_gauth_tmp('invalid').nil?
-		assert !User.find_by_gauth_tmp(User.find(1).gauth_tmp).nil?
+		assert User.find_by(gauth_tmp: 'invalid').nil?
+		assert !User.find_by(gauth_tmp: User.find(1).gauth_tmp).nil?
 	end
 
 	test 'testing token validation' do


### PR DESCRIPTION
We can merge (and change reference in gemfile) when we move production to rails 4.