### PR TITLE
Fixed scope of translation file

### DIFF
--- a/app/controllers/devise/checkga_controller.rb
+++ b/app/controllers/devise/checkga_controller.rb
@@ -41,6 +41,10 @@ class Devise::CheckgaController < Devise::SessionsController
     end
   end
 
+  def translation_scope
+    'devise.checkga'
+  end
+
   private
 
   def devise_resource

--- a/app/controllers/devise/displayqr_controller.rb
+++ b/app/controllers/devise/displayqr_controller.rb
@@ -22,6 +22,10 @@ class Devise::DisplayqrController < DeviseController
     end
   end
 
+  def translation_scope
+    'devise.displayqr'
+  end
+
   private
   def scope
     resource_name.to_sym

--- a/app/controllers/devise/recovery_codes_controller.rb
+++ b/app/controllers/devise/recovery_codes_controller.rb
@@ -47,6 +47,10 @@ class Devise::RecoveryCodesController < DeviseController
     end
   end
 
+  def translation_scope
+    'devise.recovery_codes'
+  end
+
   private
   def scope
     resource_name.to_sym

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,4 +23,7 @@ en:
       download:
         title: "Download your recovery codes"
         button: "Download codes"
+      user:
+        error: "Invalid recovery codes"
+
 


### PR DESCRIPTION
Devise introduced a new method to find the scope of the local file.
The old behaviour was "devise.#{controller_name}" so it worked fine,
but they changed it to use whatever the parent define. In this case,
the scope changes from 'en.devise.checkga.user.error' to
'en.devise.sessions.user.error'.

See : https://github.com/plataformatec/devise/commit/c2fb80d4d9482cc9e923d2434556f2aadc4cbd3c